### PR TITLE
Recognise common Malta NIC-managed 2nd-level domains

### DIFF
--- a/countries/mt.js
+++ b/countries/mt.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = [
+    'com',
+    'edu',
+    'net',
+    'org',
+];

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ let slds = {
     at: require('./countries/at.js'),
     au: require('./countries/au.js'),
     br: require('./countries/br.js'),
+    mt: require('./countries/mt.js'),
     mx: require('./countries/mx.js'),
     nz: require('./countries/nz.js'),
     sg: require('./countries/sg.js'),


### PR DESCRIPTION
Similarly to `.uk`, it looks like you can now register any `.mt`
2nd level domain, but these 4 are those the NIC availability form
at https://www.nic.org.mt/dotmt/ currently list so are presumably
those which we can safely assume belong to distinct entities when
the 3rd level varies.